### PR TITLE
Ensure metadata reflects aggregated scores.

### DIFF
--- a/gw.trans.scores.R
+++ b/gw.trans.scores.R
@@ -184,6 +184,8 @@ for (this.gwasid in gwas.with.many.scores[, gwasid]) {
 }
 
 ans <- ans[order(gene_symbol)]
+trans.genome.wide.scoresinfo <- ans[(qtl_type=="cis" | qtl_type=="cis-x") |
+                                    (qtl_type=="trans" &  minpvalue<1E-6)]
 
 #' Check that all scores were aggregated correctly.
 ##------------------------------------------------------------------------------
@@ -198,7 +200,6 @@ stopifnot(identical(all.trans[order(all.trans)], trans[order(trans)]))
 
 #' Save processed scores.
 ##------------------------------------------------------------------------------
-trans.genome.wide.scoresinfo <- ans
 save(genome.wide.scores,
      file=file.path(output.dir, "trans.genotypicscore.1e-6.Rdata.gz"))
 save(trans.genome.wide.scoresinfo,


### PR DESCRIPTION
When we aggregate multiple _trans_ scores, we end up in a state where individual `scoreid` in metadata no longer point to correct columns in the scores matrix. This is resolved by creating new `scoreid` both in metadata and in scores matrix. These are named as: `X_gwasid_trans` and will be non-unique. These will be repeated in the metadata for each score which was aggregated in the scores matrix.

This fix also adds a few checks to be absolutely sure that we do not end up in a position when there are some `scoreid` in metadata which point to non-existing scores in scores matrix.

Furthermore, we ensure that there are no scores in the scores matrix which are not reflected in the metadata (this was unlikely even in the old code but the check was still added).